### PR TITLE
chore: update CI/CD actions to v4 and fix npm publish

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,9 +19,9 @@ jobs:
         node-version: [23.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -33,12 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 23
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [23.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
## Summary

- `actions/checkout@v3` e `actions/setup-node@v3` atualizados para `@v4` (CI e CD)
- `JS-DevTools/npm-publish@v1` substituído por `npm publish` nativo com `NODE_AUTH_TOKEN` via `setup-node registry-url`

## Por que isso falhou

O job `publish` do CD workflow falhou com `npm publish exited with a status of 1`. A action `JS-DevTools/npm-publish@v1` usa Node 20 internamente, que foi **deprecado nos runners do GitHub com cutoff em 2026-06-02**. Além disso, a action de terceiro é menos confiável que o publish nativo.

## O que foi alterado

- Todas as actions atualizadas para versões que usam Node 20+ (runners modernos)
- Publish agora usa o padrão oficial: `setup-node` com `registry-url` configura `.npmrc` automaticamente, e `npm publish` lê `NODE_AUTH_TOKEN` do secret `NPM_TOKEN`

## ⚠️ Ação necessária

O secret `NPM_TOKEN` precisa estar válido em **Settings → Secrets and variables → Actions → NPM_TOKEN**. Se o token expirou ou nunca foi configurado, o publish continuará falhando mesmo com as actions atualizadas.

## Test plan

- [ ] CI (build + test) passa no Node 23.x sem warnings de deprecação
- [ ] CD publish roda com `npm publish` nativo
- [ ] Confirmar que `NPM_TOKEN` está válido no GitHub Secrets

https://claude.ai/code/session_01DmwGP3vFPhjWfWvZBfiWqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmwGP3vFPhjWfWvZBfiWqw)_